### PR TITLE
Fix typo in `generateInspectStyle`

### DIFF
--- a/lib/stylegen.js
+++ b/lib/stylegen.js
@@ -128,7 +128,7 @@ function generateInspectStyle(originalMapStyle, coloredLayers, opts) {
 
   return Object.assign(originalMapStyle, {
     layers: [backgroundLayer].concat(coloredLayers),
-    sources: sources
+    sources
   });
 }
 

--- a/lib/stylegen.js
+++ b/lib/stylegen.js
@@ -128,7 +128,7 @@ function generateInspectStyle(originalMapStyle, coloredLayers, opts) {
 
   return Object.assign(originalMapStyle, {
     layers: [backgroundLayer].concat(coloredLayers),
-    soources: sources
+    sources: sources
   });
 }
 


### PR DESCRIPTION
Tiny typo I noticed while tracing through the code in the debugger.

Seems to date back to `mapbox-gl-inspect`, and prevented the `forEach(sourceId)` loop from actually doing anything.

Typo introduced here: https://github.com/lukasmartinelli/mapbox-gl-inspect/commit/6bbe9848d695a72cba7ddae95ce5fe8eb3c8e115